### PR TITLE
Feedback more accurately calcs network size

### DIFF
--- a/20180814_PersonalNetworks_datafeedback_code.R
+++ b/20180814_PersonalNetworks_datafeedback_code.R
@@ -13,7 +13,7 @@
 #					 study_id's.
 # AUTHOR:  Liam McCafferty, Meghan Hutch, Nuzulul Kurniansyah, Amar Dhand
 # CREATED: 06/08/18
-# LATEST:  08/14/18
+# LATEST:  09/20/18
 # NOTES:   Code works on raw .csv outputs from REDCap, no processing required.
 # ##############################################################################
 
@@ -296,8 +296,7 @@ make_table <- function(x) {
   # Inputs: x = input dataset with 1 row
   # Ouputs: table, a single graphical table which contains health stats from dataset
   ##########
-  x <- dataset[3,]
-  
+
   #transform data to dataframe-table
   x <- tbl_df(x)
   
@@ -311,10 +310,10 @@ make_table <- function(x) {
     #   proportion of them (in relation to the total tie count) which are 1.
     # Inputs: prop_check = set of isolated variables with na's and unused data stripped
     # Ouputs: proportion (in percentages) of 1's to used network size.
-    # Notes: Checks all varaibles! You will need to get rid of unused variables.
+    # Notes: Checks all variables! You will need to get rid of unused variables.
     #   As well the tie identifies are determined by the first 8 characters of the
-    #   varaible names. Variable names require 2 things: tie identifiers must be
-    #   before and seperate from variable identifiers, tie identfiers must be either
+    #   variable names. Variable names require 2 things: tie identifiers must be
+    #   before and separate from variable identifiers, tie identfiers must be either
     #   farther than 8 characters from the beginning or change the "width" value to
     #   cut variable identifiers out)
     ##########

--- a/20180814_PersonalNetworks_datafeedback_code.R
+++ b/20180814_PersonalNetworks_datafeedback_code.R
@@ -13,7 +13,7 @@
 #					 study_id's.
 # AUTHOR:  Liam McCafferty, Meghan Hutch, Nuzulul Kurniansyah, Amar Dhand
 # CREATED: 06/08/18
-# LATEST:  08/30/18
+# LATEST:  08/14/18
 # NOTES:   Code works on raw .csv outputs from REDCap, no processing required.
 # ##############################################################################
 
@@ -296,7 +296,7 @@ make_table <- function(x) {
   # Inputs: x = input dataset with 1 row
   # Ouputs: table, a single graphical table which contains health stats from dataset
   ##########
-  
+  x <- dataset[3,]
   
   #transform data to dataframe-table
   x <- tbl_df(x)
@@ -311,10 +311,10 @@ make_table <- function(x) {
     #   proportion of them (in relation to the total tie count) which are 1.
     # Inputs: prop_check = set of isolated variables with na's and unused data stripped
     # Ouputs: proportion (in percentages) of 1's to used network size.
-    # Notes: Checks all variables! You will need to get rid of unused variables.
+    # Notes: Checks all varaibles! You will need to get rid of unused variables.
     #   As well the tie identifies are determined by the first 8 characters of the
-    #   variable names. Variable names require 2 things: tie identifiers must be
-    #   before and separate from variable identifiers, tie identfiers must be either
+    #   varaible names. Variable names require 2 things: tie identifiers must be
+    #   before and seperate from variable identifiers, tie identfiers must be either
     #   farther than 8 characters from the beginning or change the "width" value to
     #   cut variable identifiers out)
     ##########
@@ -339,6 +339,7 @@ make_table <- function(x) {
   #Calculate Network size
   names_fill <- x %>% select(name1, name2, name3, name4, name5, name6, name7, name8,
                              name9, name10, name11, name12, name13, name14, name15)
+  names_fill <- names_fill[1 == select(x ,name_1:name_15)]
   names_box1 <- strsplit(as.character(x$more_names_1), split = ",")
   names_box2 <- strsplit(as.character(x$more_names_2), split = ",")
   names_box3 <- strsplit(as.character(x$more_names_3), split = ",")
@@ -348,9 +349,12 @@ make_table <- function(x) {
   names_box2 <- as.vector(unlist(names_box2, use.names = FALSE))
   names_box3 <- as.vector(unlist(names_box3, use.names = FALSE))
   
-  names_total <- c(names_fill, names_box1, names_box2, names_box3)
-  names_total <- unique(toupper(trimws(names_total)))
-  names_total <- names_total[names_total != ""] 
+  names_boxes <- c(names_box1, names_box2, names_box3)
+  names_boxes <- unique(toupper(trimws(names_boxes)))
+  names_boxes <- names_boxes[names_boxes != ""]
+  
+  names_boxes <- names_boxes[!(names_boxes %in% toupper(names_fill))]
+  names_total <- c(names_boxes, toupper(names_fill))
   
   size <- length(names_total)
   size <- paste(size, "People")


### PR DESCRIPTION
Changed the feedback code to more accurately calculate the network size. Unfortunately I couldn't use the same method as the clean-code2 as that method has batching built in, while my version is for-looping. The problem was that two separate persons identified in the original network were getting eliminated even thought the respondent indicated they were separate people. Now the code takes this into consideration, while still eliminating box names that are the same as the original names.