### PR TITLE
Correcting for record_id variable

### DIFF
--- a/20180814_PersonalNetworks_cleandata1_code.R
+++ b/20180814_PersonalNetworks_cleandata1_code.R
@@ -34,6 +34,9 @@ sample_data <- read.csv("20180807_PersonalNetwork_data.csv",
 #Stores "sample_data" as a table data frame for easier reading
 sample_data <- tbl_df(sample_data)
 
+#Check if REDCap has changed study_id to record_id, replace if so
+colnames(sample_data)[colnames(sample_data) == "record_id"] <- "study_id"
+
 ##The remaining code sets variable types and assigns levels to categorical
 #  variables. We given a detailed annotation of this process for the variable 
 #  "sex" below. Subsequent variables follow the same pattern. 

--- a/20180814_PersonalNetworks_datafeedback_code.R
+++ b/20180814_PersonalNetworks_datafeedback_code.R
@@ -45,6 +45,9 @@ library(grid) # For montage of networks
 #Imports data and assigns it to variable "dataset"
 dataset <- read.csv("20180807_PersonalNetwork_data.csv")
 
+#Check if REDCap has changed study_id to record_id, replace if so
+colnames(dataset)[colnames(dataset) == "record_id"] <- "study_id"
+
 #Function which makes a basic network matrix used by multiple functions
 make_base_mat <- function(x){
   ##########


### PR DESCRIPTION
Added a single line of code (and descriptive comment) to correct for if REDCap refers to the "study_id" as "record_id". The code will simply change the name of this variable to "study_id" and then proceed normally.