### PR TITLE
Preserving Sample Data order

### DIFF
--- a/20180814_PersonalNetworks_cleandata2_code.R
+++ b/20180814_PersonalNetworks_cleandata2_code.R
@@ -59,6 +59,9 @@ library(igraph) # To transform and analyze network data
 
 #Load temp file created from 2nd part of code
 load("temp.rda")
+#In case study id's are out of order, this will reorder them to ensure that functions
+#  can preserve order and output information correctly.
+sample_data <- sample_data[order(sample_data$study_id), ]
 
 #Select study_id and each relationship tie
 shape <- sample_data %>% select(study_id, tie1:a_tie105) %>%


### PR DESCRIPTION
Fixing an issue where if study_id's were not ordered for some reason (REDCap normally outputs in order, however this is not always guaranteed) the functions would normally output information in increasing study_id order. This fix reorders study_id's to be increasing,  thus preserving order within functions.