### PR TITLE
packagefix for feedback code

### DIFF
--- a/20180814_PersonalNetworks_datafeedback_code.R
+++ b/20180814_PersonalNetworks_datafeedback_code.R
@@ -47,7 +47,7 @@ dataset <- read.csv("20180807_PersonalNetwork_data.csv")
 
 #Check if REDCap has changed record_id to record_id, replace if so
 colnames(dataset)[colnames(dataset) == "record_id"] <- "record_id"
-x <- dataset[1,]
+
 #Function which makes a basic network matrix used by multiple functions
 make_base_mat <- function(x){
   ##########

--- a/20180814_PersonalNetworks_datafeedback_code.R
+++ b/20180814_PersonalNetworks_datafeedback_code.R
@@ -47,7 +47,7 @@ dataset <- read.csv("20180807_PersonalNetwork_data.csv")
 
 #Check if REDCap has changed record_id to record_id, replace if so
 colnames(dataset)[colnames(dataset) == "record_id"] <- "record_id"
-
+x <- dataset[1,]
 #Function which makes a basic network matrix used by multiple functions
 make_base_mat <- function(x){
   ##########
@@ -126,17 +126,18 @@ make_net_array <- function(l){
     colors <- c("1" = "blue", "2" = "red")
     
     #Creates unique color palette for "ego" node
-    ego_col <- ifelse(V(ego_g)$name == "EGO", "black", "white")
+    V(ego_g)$ego_col <- ifelse(V(ego_g)$name == "EGO", "black", "white")
     
     #Determines structures of networks
     ggplot(ego_g, aes(x = x, y = y, xend = xend, yend = yend)) + 
       #Determines curvature and thickness of lines (unweighted)
       geom_edges(aes(color = as.factor(weight)), curvature = 0.1) +
       #Determines size and shape of nodes (shape21 = circle)
-      geom_nodes(fill = ego_col, size = 1, shape = 21) +
+      geom_nodes(aes(fill = ego_col), size = 1, shape = 21) +
       #Eliminates labels on each matrix
       theme_blank(legend.position = "none") +
       scale_color_manual(values = colors) +
+      scale_fill_manual(values = c("black", "white")) +
       ggtitle(names(matrix_list[z]))
   }
   
@@ -242,11 +243,10 @@ make_image <- function(x) {
   
   #Saves important values for determining graph formatting
   ego4.g  <- graph.adjacency(mat, mode = "undirected", weighted = TRUE)
-  colors  <- c("blue", "red") #create color palette for ties
-  ego_col <- ifelse(V(ego4.g)$name == "You", "grey17", "white") 
+  V(ego4.g)$ego_col <- ifelse(V(ego4.g)$name == "You", "grey17", "white") 
   
   #Saves logic to determine the strength of ties between nodes
-  weight.ego <- sapply(E(ego4.g)$weight, function(yk){
+  E(ego4.g)$weight_cat <- sapply(E(ego4.g)$weight, function(yk){
     if(is.na(yk)){
       return("Unknown")
     }else if(yk == 1){
@@ -256,7 +256,7 @@ make_image <- function(x) {
     }
   })
   
-  if ("Unknown" %in% weight.ego ){
+  if ("Unknown" %in% E(ego4.g)$weight_cat ){
     #Error check to see if network has sufficient ties, will output a blank graph with
     #  error message.
     print("Error: Some networks ties are unknown ")
@@ -264,15 +264,15 @@ make_image <- function(x) {
       geom_blank() + ggtitle("Data doesn't work: some network ties are unknown")
       
   }else{
-    E(ego4.g)$weight <- weight.ego
+    # E(ego4.g)$weight <- weight.ego
     #Creates actual network graph
     plot1 <- ggplot(ego4.g, aes(x = x, y = y, xend = xend, yend = yend, na.rm = FALSE)) + 
       #Determines coloration and style of network edges
-      geom_edges(aes(linetype = as.factor(weight), color = (weight)), curvature = 0.1) +
+      geom_edges(aes(linetype = weight_cat, color = weight_cat), curvature = 0.1) +
       #Fills nodes with ego_color pallate
-      geom_nodes(fill = ego_col, size = 14, shape = 21) +
+      geom_nodes(aes(fill = ego_col), size = 14, shape = 21) +
       #Names each node with alter names
-      geom_nodelabel(label = rownames(mat))+
+      geom_nodelabel(aes(label = name)) +
       theme_blank() +
       #Formats the legend which describes edge weight to the reader
       theme(legend.position = "bottom", #format the legend 
@@ -280,12 +280,14 @@ make_image <- function(x) {
             legend.text = element_text(size = 10)) + 
       theme(legend.title.align = 0.5) + 
       theme(plot.title = element_text(size = 18, face = "bold")) +
-      scale_colour_manual(name = "Tie Strength", values = c("red", "blue"))+
+      scale_colour_manual(name = "Tie Strength", values = c("red", "blue")) +
+      scale_fill_manual(values = c("grey17", "white")) +
       scale_shape_manual(name = "Tie Strength", values = c(22, 21)) +
       scale_linetype_manual(name = "Tie Strength", values = c("solid", "dashed")) +
       #Determins the margins around plot
       theme(plot.margin = unit(c(1.5, 1.5, 1.5, 1.5), "cm")) +
       #Formatting for legend's keys
+      guides(fill = FALSE) +
       theme(legend.direction = 'vertical',
             legend.key.height = unit(1, "line"),
             legend.key = element_rect(colour = NA, fill = NA))

--- a/20180814_PersonalNetworks_datafeedback_code.R
+++ b/20180814_PersonalNetworks_datafeedback_code.R
@@ -13,7 +13,7 @@
 #					 record_id's.
 # AUTHOR:  Liam McCafferty, Meghan Hutch, Nuzulul Kurniansyah, Amar Dhand
 # CREATED: 06/08/18
-# LATEST:  09/20/18
+# LATEST:  05/12/20
 # NOTES:   Code works on raw .csv outputs from REDCap, no processing required.
 # ##############################################################################
 


### PR DESCRIPTION
Fixed issue where feedback code was unable to function correctly due to some changes in the packages ggnetwork or igraph. Originally accessing the tie weight or other edge/vertice data was inconsistent within the ggplot2 object, so saving it as a separate variable proved more effective. However, due to changes in packages, we found that external variables were now inconsistent in their assignment order and any issues accessing data within the igraph object were much more effective. Thus we transferred to assigning all edge/vertice data into the igraph object itself and then accessing them using ggplot2 aes() arguments, which seemed to solve all issues.